### PR TITLE
Update openSUSE repo

### DIFF
--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -25,7 +25,7 @@
 					<p><a href="https://fedoraproject.org/wiki/Changes/LXQt"><span class="label">Fedora</span> <img src="/images/fedora-logo-22.png" title="Fedora packages" alt="Fedora"></a></p>
 				</li>
 				<li>
-					<p><a href="http://download.opensuse.org/repositories/X11:/lxde:/lxqt/"><span class="label">openSUSE</span> <img src="/images/opensuse-logo-22.png" title="openSUSE packages" alt="openSUSE"></a></p>
+					<p><a href="http://download.opensuse.org/repositories/X11:/lxde/openSUSE_13.2/"><span class="label">openSUSE</span> <img src="/images/opensuse-logo-22.png" title="openSUSE packages" alt="openSUSE"></a></p>
 				</li>
 				<li>
 					<p><a href="https://abf.io/openmandriva/task-lxqt"><span class="label">OpenMandriva</span> <img src="/images/openmandriva-logo-22.png" title="OpenMandriva packages" alt="OpenMandriva Lx"></a></p>


### PR DESCRIPTION
Upating to valid 13.2 repo.
X11:lxde:lxqt subproject seems to be deleted.