### PR TITLE
Update Mageia link

### DIFF
--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -34,7 +34,7 @@
 					<p><a href="http://packages.siduction.org/lxqt"><span class="label">Siduction</span> <img src="/images/siduction-logo-22.png" title="Siduction packages" alt="Siduction"></a></p>
 				</li>
 				<li>
-					<p><a href="http://mageia.madb.org/package/show/release/cauldron/application/0/name/task-lxqt"><span class="label">Mageia</span> <img src="/images/mageia-logo-22.png" title="Mageia Metapackage" alt="Mageia"></a></p>
+					<p><a href="http://mageia.madb.org/package/show/application/0/name/task-lxqt"><span class="label">Mageia</span> <img src="/images/mageia-logo-22.png" title="Mageia Metapackage" alt="Mageia"></a></p>
 				</li>
 				<li>
 					<p><a href="https://sourceforge.net/projects/manjarolinux/files/community/LXQT/"><span class="label">Manjaro</span> <img src="/images/manjaro-logo-22.png" title="Manjaro ISOs" alt="Manjaro"></a></p>


### PR DESCRIPTION
Addresses lxde/lxqt#734 and should be pretty self-explanatory. Notes:

I was actually trying to push this myself but didn't have permission.
This made me wonder whether granting permissions like this may help both guys like me and those having permissions already save some time (e. g. by avoiding PRs like this one...).

There are two places where downstream links are listed right now: the [GitHub wiki's start page](https://github.com/lxde/lxqt/wiki) and [lxqt.org](http://lxqt.org) itself.
Not sure whether maintaining both in parallel makes sense in the long run.