### PR TITLE
home: Avoid blank padding for current screenshots

### DIFF
--- a/styles/lxqt.scss
+++ b/styles/lxqt.scss
@@ -633,7 +633,7 @@
 	#article-home_preview
 	{
 		position: relative;
-		padding-top: 62.5%;
+		padding-top: 56.25%;
 		padding-left: 0;
 		margin-bottom: 2.25rem;
 		background-color: #111;


### PR DESCRIPTION
Actually I don't know, how the web works and if the value can somehow be computed based on the current screenshots.

But this number will work for current screenshots.