### PR TITLE
Lubuntu LXQt wiki more canonical than daily PPA

### DIFF
--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -52,7 +52,7 @@
           <p><a href="https://en.opensuse.org/LXQT"><span class="label">openSUSE</span> <img src="/images/opensuse-logo-22.png" title="openSUSE packages" alt="openSUSE"></a></p>
         </li>
         <li>
-          <p><a href="https://wiki.ubuntu.com/Lubuntu/LXQt"><span class="label">Ubuntu</span> <img src="/images/ubuntu-logo-22.png" title="Ubuntu PPA" alt="Ubuntu"></a></p>
+          <p><a href="https://wiki.ubuntu.com/Lubuntu/LXQt"><span class="label">Ubuntu</span> <img src="/images/ubuntu-logo-22.png" title="Ubuntu wiki on LXQt" alt="Ubuntu"></a></p>
         </li>
       </ul>
     </main>

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -52,7 +52,7 @@
           <p><a href="https://en.opensuse.org/LXQT"><span class="label">openSUSE</span> <img src="/images/opensuse-logo-22.png" title="openSUSE packages" alt="openSUSE"></a></p>
         </li>
         <li>
-          <p><a href="https://launchpad.net/~lubuntu-dev/+archive/lubuntu-daily"><span class="label">Ubuntu</span> <img src="/images/ubuntu-logo-22.png" title="Ubuntu PPA" alt="Ubuntu"></a></p>
+          <p><a href="https://wiki.ubuntu.com/Lubuntu/LXQt"><span class="label">Ubuntu</span> <img src="/images/ubuntu-logo-22.png" title="Ubuntu PPA" alt="Ubuntu"></a></p>
         </li>
       </ul>
     </main>


### PR DESCRIPTION
The Lubuntu daily PPA is not the recommended way of installing LXQt in Ubuntu. At this point, the metapackage doesn't function, among other problems. As of Xenial, we have had lxqt packages in the repos, so there's no reason not to recommend that instead. Additionally, more information about the future of LXQt in Lubuntu is available here. 

Oh, and don't worry. I keep saying Lubuntu because we're the part of the Ubuntu family that cares most about the future of LXDE/LXQt. You can just as easily install in Ubuntu. ☺