### PR TITLE
Link to GitHub Tarballs for downloads

### DIFF
--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -16,7 +16,7 @@
           <p><a href="https://github.com/lxde"><span class="label">GitHub</span> <img src="/images/github-logo-22.png" title="GitHub repository" alt="GitHub"></a></p>
         </li>
         <li>
-          <p><a href="http://downloads.lxqt.org/lxqt/"><span class="label">Source downloads</span> <img src="/images/source-22.png" title="Source downloads"></a></p>
+          <p><a href="https://github.com/lxde/lxqt/wiki/Tarballs"><span class="label">Source downloads</span> <img src="/images/source-22.png" title="Source downloads"></a></p>
         </li>
         <li>
           <p><a href="http://packages.altlinux.org/en/search?query=lxqt"><span class="label">ALT Linux</span> <img src="/images/altlinux-logo-22.png" title="ALT packages" alt="ALT Linux"></a></p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,7 +41,7 @@
 							<li><p><a href="/releases/">Releases</a></p></li>
 							<li><p><a href="/screenshots/">Screenshots</a></p></li>
 							<li><p><a href="https://github.com/lxde/lxqt/blob/master/CONTRIBUTING.md">Contribute</a></p></li>
-							<li><p><a href="http://downloads.lxqt.org/lxqt/0.10.0/">Downloads</a></p></li>
+							<li><p><a href="https://github.com/lxde/lxqt/wiki/Tarballs">Downloads</a></p></li>
 							<li><p><a href="http://blog.lxde.org">LXDE Blog</a></p></li>
 						</ul>
 					</main>


### PR DESCRIPTION
Since downloads.lxqt.org is down for quite a while, and users keep on
asking on IRC about it, I propose to adapt the link to point to the
Tarball article in the wiki.
Once the server is up again we can change it back.