### PR TITLE
Replace highlighter Pygments with Rouge

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,7 +30,7 @@ defaults:
         values:
             unrelunimp:
                 - screenshots.html
-highlighter: pygments
+highlighter: rouge
 markdown: kramdown
 sass:
     sass_dir: styles


### PR DESCRIPTION
Pygments isn't available on github.io hence it's usage triggers a harmless but annoying warning that's by default sent by mail to submitters of commits.