### PR TITLE
Jekyll: Don't display time of day

### DIFF
--- a/_includes/posts.html
+++ b/_includes/posts.html
@@ -9,7 +9,7 @@
 								<ul>{% for post in site.posts limit:5 %}
 									<li>
 										<p><strong class="title"><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></strong><br/>
-											<time datetime="{{ post.date | date: '%F %R' }}">{{ post.date | date: '%R %A, %-d %B, %Y' }}</time></p>
+											<time datetime="{{ post.date | date: '%F %R' }}">{{ post.date | date: '%A, %-d %B, %Y' }}</time></p>
 									</li>{% endif %}{% endfor %}
 								</ul>
 							</main>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,7 @@ layout: default
 						<hgroup>
 							<h1>{{ page.title }}</h1>
 						</hgroup>
-						<p class="date"><time datetime="{{ page.date | date: '%F %R' }}">{{ page.date | date: '%R %A, %-d %B, %Y' }}</time></p>
+						<p class="date"><time datetime="{{ page.date | date: '%F %R' }}">{{ page.date | date: '%A, %-d %B, %Y' }}</time></p>
 						{% if page.author %}<p class="author">{{ page.author }}</p>{% endif %}
 					</header>
 					<div class="wrapper">

--- a/releases.html
+++ b/releases.html
@@ -9,7 +9,7 @@ slug: releases
 		<hgroup>
 			<h1><a href="{{ post.url }}">{{ post.title }}</a></h1>
 		</hgroup>
-		<p class="date"><time datetime="{{ post.date | date: '%F %R' }}">{{ post.date | date: '%R %A, %-d %B, %Y' }}</time></p>
+		<p class="date"><time datetime="{{ post.date | date: '%F %R' }}">{{ post.date | date: '%A, %-d %B, %Y' }}</time></p>
 		{% if post.author %}<p class="author">{{ post.author }}</p>{% endif %}
 	</header>
 	<div class="wrapper">


### PR DESCRIPTION
This PR removes the display of the time e. g. in the list of releases at [lxqt.org/releases](http://lxqt.org/releases/) and pages displaying particular posts like [lxqt.org/release/2016/09/17/libsysstat-032-libqtxdg-200/](http://lxqt.org/release/2016/09/17/libsysstat-032-libqtxdg-200/).

In general displaying the time doesn't make too much sense when it comes to stuff like release announcements, in particular midnight / `00:00` that's displayed all over the place right now is simply odd.

Note the PR does not change the HTML tags but only what's displayed at the pages and hence shouldn't impair the Jekyll internals in any way.